### PR TITLE
Relaxed event name constraint

### DIFF
--- a/lib/cronEmitter.js
+++ b/lib/cronEmitter.js
@@ -45,11 +45,10 @@ CronEmitter.prototype.add = function(crontab, name, options) {
         );
     }
 
-    // Verify that the event name only contains letters and underscores
-    if ( !(name.match(/[a-zA-Z_]/)) ) {
+    // Verify that the event name is a string
+    if ( typeof name !== 'string' ) {
         throw new TypeError(
-            'second argument must be name of the event consisting of ' +
-            'the characters a-z, A-Z and _'
+            'second argument must be name of the event consisting of a string'
         );
     }
 


### PR DESCRIPTION
There is no reason why an event name sould only be forged from a combinaison of ascii alphabetic or '_' characters.
